### PR TITLE
Update page title and enhance Dashboard functionality with event fetc…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ptsc-frontend</title>
+    <title>PTSC-KNIT SULTANPUR</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This pull request enhances the admin event registrations table in the dashboard by improving usability and display of registration data. The main improvements include showing event names instead of IDs, adding the ability to expand rows to view additional dynamic fields, and providing clearer context for filtered registrations. Minor UI and code structure improvements are also included.

**Event registrations table improvements:**

* Event names are now displayed instead of raw event IDs, making the table easier to read and understand. [[1]](diffhunk://#diff-582174a571900f53fa9db11e28cbde06fcc8bec2f60ad138d073e72e58835e27R202-R220) [[2]](diffhunk://#diff-582174a571900f53fa9db11e28cbde06fcc8bec2f60ad138d073e72e58835e27R575-R627)
* Admins can now expand registration rows to view additional dynamic fields, improving visibility of custom registration data. Expand/collapse controls are shown only when dynamic fields are present. [[1]](diffhunk://#diff-582174a571900f53fa9db11e28cbde06fcc8bec2f60ad138d073e72e58835e27R44) [[2]](diffhunk://#diff-582174a571900f53fa9db11e28cbde06fcc8bec2f60ad138d073e72e58835e27R202-R220) [[3]](diffhunk://#diff-582174a571900f53fa9db11e28cbde06fcc8bec2f60ad138d073e72e58835e27R575-R627) [[4]](diffhunk://#diff-582174a571900f53fa9db11e28cbde06fcc8bec2f60ad138d073e72e58835e27L14-R16)
* The table now includes an "Actions" column for expand/collapse controls.

**Dashboard UI improvements:**

* When viewing registrations, the dashboard now clearly indicates whether all registrations are shown or filtered by event, including the event name and count.

**Other minor changes:**

* The dashboard now fetches the list of events before fetching registrations to ensure event names are available for display.
* The page title in `index.html` has been updated to "PTSC-KNIT SULTANPUR".
* A debug `console.log` was added for registration data.